### PR TITLE
Changes in configuration to make cassandra run on alpine 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,15 +29,22 @@ LABEL \
     org.label-schema.vcs-url="https://github.com/chrislovecnm/docker-cassandra"
 
 ENV CASSANDRA_HOME=/usr/local/apache-cassandra-${CASSANDRA_VERSION} \
-    JAVA_HOME=/usr/lib/jvm/default-jvm \
-    PATH=$PATH:${JAVA_HOME}/bin:${CASSANDRA_HOME}/bin
+    CASSANDRA_CONF=/etc/cassandra \
+    CASSANDRA_DATA=/cassandra_data \
+    CASSANDRA_LOGS=/var/log/cassandra \
+    JAVA_HOME=/usr/lib/jvm/default-jvm
+
+ENV PATH=${PATH}:${JAVA_HOME}/bin:${CASSANDRA_HOME}/bin
+
+# Alpine jemalloc library path is not expected by C*, so we need to provide it
+#ENV CASSANDRA_LIBJEMALLOC=/usr/lib/libjemalloc.so.2
 
 ADD files /
 
 RUN set -x \
     && apk --no-cache add \
         bash \
-        jemalloc \
+#        jemalloc \
         openjdk8-jre \
         python \
         dumb-init \
@@ -62,7 +69,7 @@ RUN set -x \
       $CASSANDRA_HOME}/tools/*.yaml \
       $CASSANDRA_HOME}/tools/bin/*.bat
 
-VOLUME ["/cassandra_data"]
+VOLUME ["/$CASSANDRA_DATA"]
 
 # 7000: intra-node communication
 # 7001: TLS intra-node communication

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Apache Cassandra docker image based on alpine
 Note that this image is unstable and under development.
 
 ```
-docker build --build-arg "VERSION=3.9" -t local/cassandra .
+docker build --build-arg "CASSANDRA_VERSION=3.9" -t local/cassandra .
 docker run --net vnet --name cassandra -d  local/cassandra 
 docker run --net vnet -it --rm local/cassandra cqlsh cassandra.vnet
 ```

--- a/files/cassandra.yaml
+++ b/files/cassandra.yaml
@@ -68,7 +68,7 @@ max_hints_delivery_threads: 2
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-# hints_directory: /var/lib/cassandra/hints
+hints_directory: /cassandra_data/hints
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -29,7 +29,10 @@ if [ "$1" = 'cassandra' ]; then
 		: ${CASSANDRA_SEEDS:="cassandra"}
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
-	
+
+	CASSANDRA_SEED_PROVIDER="${CASSANDRA_SEED_PROVIDER:-org.apache.cassandra.locator.SimpleSeedProvider}"
+	sed -ri 's/- class_name: SEED_PROVIDER/- class_name: '"$CASSANDRA_SEED_PROVIDER"'/' "$CASSANDRA_CONF/cassandra.yaml"
+
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONF/cassandra.yaml"
 
 	for yaml in \
@@ -61,7 +64,7 @@ if [ "$1" = 'cassandra' ]; then
 		fi
 	done
 
-	exec su-exec cassandra "$@"
+	exec su -s /bin/sh cassandra -c "$*"
 fi
 
 exec "$@"


### PR DESCRIPTION
I commented jemalloc library due using it leads JVM to crash. I've found some simillar issues in other projects: https://github.com/voidlinux/void-packages/commit/16e778e05c8dff613cc1744280890786a871ff30 


Also, i tried to use Cassandra on alpine(anapsix/alpine-java:8) in my projects , but I had to go back to containers on the basis of Ubuntu\Debian. I suggest not to use the alpine at this moment, unless the goal is to run cassandra on alpine at any cost